### PR TITLE
Improve LoRa Module driver

### DIFF
--- a/twr/inc/twr_cmwx1zzabz.h
+++ b/twr/inc/twr_cmwx1zzabz.h
@@ -204,6 +204,8 @@ typedef enum
     TWR_CMWX1ZZABZ_CONFIG_INDEX_NWK = 10,
     TWR_CMWX1ZZABZ_CONFIG_INDEX_ADAPTIVE_DATARATE = 11,
     TWR_CMWX1ZZABZ_CONFIG_INDEX_DATARATE = 12,
+    TWR_CMWX1ZZABZ_CONFIG_INDEX_REP = 13,
+    TWR_CMWX1ZZABZ_CONFIG_INDEX_RTYNUM = 14,
     TWR_CMWX1ZZABZ_CONFIG_INDEX_LAST_ITEM
 
 } twr_cmwx1zzabz_config_index_t;
@@ -254,6 +256,8 @@ typedef struct
     uint8_t nwk_public;
     bool adaptive_datarate;
     uint8_t datarate;
+    uint8_t repetition_unconfirmed;
+    uint8_t repetition_confirmed;
 
 } twr_cmwx1zzabz_config;
 
@@ -600,6 +604,30 @@ bool twr_cmwx1zzabz_get_link_check(twr_cmwx1zzabz_t *self, uint8_t *margin, uint
 //! @return Pointer to the string containing version
 
 char *twr_cmwx1zzabz_get_fw_version(twr_cmwx1zzabz_t *self);
+
+//! @brief Set number of transmissions of unconfirmed message
+//! @param[in] self Instance
+//! @param[in] repeat Number of transmissions
+
+void twr_cmwx1zzabz_set_repeat_unconfirmed(twr_cmwx1zzabz_t *self, uint8_t repeat);
+
+//! @brief Get number of transmissions of unconfirmed message
+//! @param[in] self Instance
+//! @return Number of transmissions
+
+uint8_t twr_cmwx1zzabz_get_repeat_unconfirmed(twr_cmwx1zzabz_t *self);
+
+//! @brief Set number of transmissions of confirmed message
+//! @param[in] self Instance
+//! @param[in] repeat Number of transmissions
+
+void twr_cmwx1zzabz_set_repeat_confirmed(twr_cmwx1zzabz_t *self, uint8_t repeat);
+
+//! @brief Get number of transmissions of confirmed message
+//! @param[in] self Instance
+//! @return Number of transmissions
+
+uint8_t twr_cmwx1zzabz_get_repeat_confirmed(twr_cmwx1zzabz_t *self);
 
 //! @}
 

--- a/twr/src/twr_cmwx1zzabz.c
+++ b/twr/src/twr_cmwx1zzabz.c
@@ -48,6 +48,8 @@ const char *_init_commands[] =
     "AT+NWK?\r",
     "AT+ADR?\r",
     "AT+DR?\r",
+    "AT+REP?\r",
+    "AT+RTYNUM?\r",
     NULL
 };
 
@@ -460,6 +462,22 @@ static void _twr_cmwx1zzabz_task(void *param)
                     }
                     response_handled = 1;
                 }
+                else if (strcmp(last_command, "AT+REP?\r") == 0 && response_valid)
+                {
+                    if ((self->_save_config_mask & 1 << TWR_CMWX1ZZABZ_CONFIG_INDEX_REP) == 0)
+                    {
+                        self->_config.repetition_unconfirmed = atoi(response_string_value);
+                    }
+                    response_handled = 1;
+                }
+                else if (strcmp(last_command, "AT+RTYNUM?\r") == 0 && response_valid)
+                {
+                    if ((self->_save_config_mask & 1 << TWR_CMWX1ZZABZ_CONFIG_INDEX_RTYNUM) == 0)
+                    {
+                        self->_config.repetition_confirmed = atoi(response_string_value);
+                    }
+                    response_handled = 1;
+                }
                 else if (strcmp(last_command, "AT+DUTYCYCLE=0\r") == 0 && strcmp(self->_response, "+ERR=-17\r") == 0)
                 {
                     // DUTYCYLE is unusable in some band configuration, ignore this err response
@@ -692,6 +710,17 @@ static void _twr_cmwx1zzabz_task(void *param)
                         snprintf(self->_command, TWR_CMWX1ZZABZ_TX_FIFO_BUFFER_SIZE, "AT+DR=%d\r", (int) self->_config.datarate);
                         break;
                     }
+                    case TWR_CMWX1ZZABZ_CONFIG_INDEX_REP:
+                    {
+                        snprintf(self->_command, TWR_CMWX1ZZABZ_TX_FIFO_BUFFER_SIZE, "AT+REP=%d\r", (int) self->_config.repetition_unconfirmed);
+                        break;
+                    }
+                    case TWR_CMWX1ZZABZ_CONFIG_INDEX_RTYNUM:
+                    {
+                        snprintf(self->_command, TWR_CMWX1ZZABZ_TX_FIFO_BUFFER_SIZE, "AT+RTYNUM=%d\r", (int) self->_config.repetition_confirmed);
+                        break;
+                    }
+
                     default:
                     {
                         break;
@@ -1217,6 +1246,30 @@ void twr_cmwx1zzabz_set_datarate(twr_cmwx1zzabz_t *self, uint8_t datarate)
 uint8_t twr_cmwx1zzabz_get_datarate(twr_cmwx1zzabz_t *self)
 {
     return self->_config.datarate;
+}
+
+void twr_cmwx1zzabz_set_repeat_unconfirmed(twr_cmwx1zzabz_t *self, uint8_t repeat)
+{
+    self->_config.repetition_unconfirmed = repeat;
+
+    _twr_cmwx1zzabz_save_config(self, TWR_CMWX1ZZABZ_CONFIG_INDEX_REP);
+}
+
+uint8_t twr_cmwx1zzabz_get_repeat_unconfirmed(twr_cmwx1zzabz_t *self)
+{
+    return self->_config.repetition_unconfirmed;
+}
+
+void twr_cmwx1zzabz_set_repeat_confirmed(twr_cmwx1zzabz_t *self, uint8_t repeat)
+{
+    self->_config.repetition_confirmed = repeat;
+
+    _twr_cmwx1zzabz_save_config(self, TWR_CMWX1ZZABZ_CONFIG_INDEX_RTYNUM);
+}
+
+uint8_t twr_cmwx1zzabz_get_repeat_confirmed(twr_cmwx1zzabz_t *self)
+{
+    return self->_config.repetition_confirmed;
 }
 
 char *twr_cmwx1zzabz_get_error_command(twr_cmwx1zzabz_t *self)


### PR DESCRIPTION
- Add support for all 3 LoRa Module firmwares (1.0.02, 1.1.03 - added FRMCNT, 1.1.06 - added JOINDC)
- Add retransmission counters
- Add timeouts
- Add FW version readout
- Add LNCHECK
- Add RFQ
- Add JOINDC, DWELL
- other improvements...

