### PR TITLE
Add a Python script to generate firmware version from git

### DIFF
--- a/git-version.py
+++ b/git-version.py
@@ -1,0 +1,11 @@
+from subprocess import check_output
+from datetime import datetime
+
+try:
+    git_version=check_output(['git', 'describe', '--abbrev=8', '--always', '--tags', '--dirty= (modified)']).decode().strip()
+except:
+    git_version='?'
+
+build_date=datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
+
+print('-D GIT_VERSION="\\"%s\\"" -D BUILD_DATE="\\"%s\\""' % (git_version, build_date))


### PR DESCRIPTION
This commit adds a simple Python script that generates command line
options for gcc with macro definitions that contain a version string
and build date obtained from git version history. The output looks
as follows:

-D GIT_VERSION="v1.1.1-3-ga2c587fc" -D BUILD_DATE="2022-01-26 16:03:25 UTC"

The script is meant to be invoked from platformio.ini in the
corresponding firmware repository as follows:

[env:debug]
build_flags =
    !python .pio/libdeps/debug/twr-sdk/git-version.py

[env:release]
build_flags =
    -D RELEASE
    !python .pio/libdeps/release/twr-sdk/git-version.py