### PR TITLE
Add support for tunneled LoRa module AT commands

### DIFF
--- a/twr/inc/twr_at_lora.h
+++ b/twr/inc/twr_at_lora.h
@@ -22,7 +22,7 @@
                          {"$FRMCNT", twr_at_lora_frmcnt, NULL, NULL, NULL, "Get frame counters"},\
                          {"$LNCHECK", twr_at_lora_link_check, NULL, NULL, NULL, "MAC Link Check"},\
                          {"$RFQ", twr_at_lora_rfq, NULL, NULL, NULL, "Get RSSI/SNR of last RX packet"},\
-                         {"$AT", NULL, twr_at_lora_custom_at_set, NULL, NULL, "Send custom AT command"},\
+                         {"$AT", twr_at_lora_custom_at, twr_at_lora_custom_at, NULL, NULL, "Send custom AT command"},\
                          {"$DEBUG", NULL, twr_at_lora_debug_set, NULL, NULL, "Show debug UART communication"},\
                          {"$REBOOT", twr_at_lora_reboot, NULL, NULL, NULL, "Firmware reboot"},\
                          {"$FRESET", twr_at_lora_freset, NULL, NULL, NULL, "LoRa Module factory reset"},\
@@ -76,7 +76,7 @@ bool twr_at_lora_freset(twr_atci_param_t *param);
 bool twr_at_lora_frmcnt(twr_atci_param_t *param);
 bool twr_at_lora_link_check(twr_atci_param_t *param);
 bool twr_at_lora_rfq(twr_atci_param_t *param);
-bool twr_at_lora_custom_at_set(twr_atci_param_t *param);
+bool twr_at_lora_custom_at(twr_atci_param_t *param);
 
 bool twr_at_lora_join(twr_atci_param_t *param);
 bool twr_at_lora_debug_set(twr_atci_param_t *param);

--- a/twr/inc/twr_at_lora.h
+++ b/twr/inc/twr_at_lora.h
@@ -22,6 +22,7 @@
                          {"$FRMCNT", twr_at_lora_frmcnt, NULL, NULL, NULL, "Get frame counters"},\
                          {"$LNCHECK", twr_at_lora_link_check, NULL, NULL, NULL, "MAC Link Check"},\
                          {"$RFQ", twr_at_lora_rfq, NULL, NULL, NULL, "Get RSSI/SNR of last RX packet"},\
+                         {"$LORA", twr_at_lora_custom_at, twr_at_lora_custom_at, NULL, NULL, "Send custom AT command to LoRa module"},\
                          {"$AT", twr_at_lora_custom_at, twr_at_lora_custom_at, NULL, NULL, "Send custom AT command"},\
                          {"$DEBUG", NULL, twr_at_lora_debug_set, NULL, NULL, "Show debug UART communication"},\
                          {"$REBOOT", twr_at_lora_reboot, NULL, NULL, NULL, "Firmware reboot"},\

--- a/twr/inc/twr_at_lora.h
+++ b/twr/inc/twr_at_lora.h
@@ -69,16 +69,16 @@ bool twr_at_lora_repu_set(twr_atci_param_t *param);
 bool twr_at_lora_repc_read(void);
 bool twr_at_lora_repc_set(twr_atci_param_t *param);
 
-bool twr_at_lora_ver_read(void);
+bool twr_at_lora_ver_read(twr_atci_param_t *param);
 
-bool twr_at_lora_reboot(void);
-bool twr_at_lora_freset(void);
-bool twr_at_lora_frmcnt(void);
-bool twr_at_lora_link_check(void);
-bool twr_at_lora_rfq(void);
+bool twr_at_lora_reboot(twr_atci_param_t *param);
+bool twr_at_lora_freset(twr_atci_param_t *param);
+bool twr_at_lora_frmcnt(twr_atci_param_t *param);
+bool twr_at_lora_link_check(twr_atci_param_t *param);
+bool twr_at_lora_rfq(twr_atci_param_t *param);
 bool twr_at_lora_custom_at_set(twr_atci_param_t *param);
 
-bool twr_at_lora_join(void);
+bool twr_at_lora_join(twr_atci_param_t *param);
 bool twr_at_lora_debug_set(twr_atci_param_t *param);
 
 #endif

--- a/twr/inc/twr_at_lora.h
+++ b/twr/inc/twr_at_lora.h
@@ -24,6 +24,7 @@
                          {"$RFQ", twr_at_lora_rfq, NULL, NULL, NULL, "Get RSSI/SNR of last RX packet"},\
                          {"$LORA", twr_at_lora_custom_at, twr_at_lora_custom_at, NULL, NULL, "Send custom AT command to LoRa module"},\
                          {"$AT", twr_at_lora_custom_at, twr_at_lora_custom_at, NULL, NULL, "Send custom AT command"},\
+                         {"$LORA>ATCI", NULL, twr_at_lora_lora2atci_set, twr_at_lora_lora2atci_read, NULL, "Send LoRa responses and events over ATCI (0: no, 1: yes)"},\
                          {"$DEBUG", NULL, twr_at_lora_debug_set, NULL, NULL, "Show debug UART communication"},\
                          {"$REBOOT", twr_at_lora_reboot, NULL, NULL, NULL, "Firmware reboot"},\
                          {"$FRESET", twr_at_lora_freset, NULL, NULL, NULL, "LoRa Module factory reset"},\
@@ -69,6 +70,9 @@ bool twr_at_lora_repu_set(twr_atci_param_t *param);
 
 bool twr_at_lora_repc_read(void);
 bool twr_at_lora_repc_set(twr_atci_param_t *param);
+
+bool twr_at_lora_lora2atci_read(void);
+bool twr_at_lora_lora2atci_set(twr_atci_param_t *param);
 
 bool twr_at_lora_ver_read(twr_atci_param_t *param);
 

--- a/twr/inc/twr_atci.h
+++ b/twr/inc/twr_atci.h
@@ -29,7 +29,7 @@ typedef struct
 typedef struct
 {
   const char *command;
-  bool (*action)(void);
+  bool (*action)(twr_atci_param_t *param);
   bool (*set)(twr_atci_param_t *param);
   bool (*read)(void);
   bool (*help)(void);
@@ -90,11 +90,11 @@ bool twr_atci_skip_response(void);
 
 //! @brief Helper for clac action
 
-bool twr_atci_clac_action(void);
+bool twr_atci_clac_action(twr_atci_param_t *param);
 
 //! @brief Helper for help action
 
-bool twr_atci_help_action(void);
+bool twr_atci_help_action(twr_atci_param_t *param);
 
 //! @brief Parse string to uint and move parsing cursor forward
 //! @param[in] param ATCI instance

--- a/twr/inc/twr_cmwx1zzabz.h
+++ b/twr/inc/twr_cmwx1zzabz.h
@@ -297,7 +297,7 @@ struct twr_cmwx1zzabz_t
     char _custom_command_buf[TWR_CMWX1ZZABZ_CUSTOM_COMMAND_BUFFER_SIZE];
     uint8_t _tx_port;
     bool _debug;
-
+    bool _atci;
     char _fw_version[TWR_CMWX1ZZABZ_FW_VERSION_BUFFER_SIZE];
 
     int32_t _cmd_rfq_rssi;

--- a/twr/src/twr_at_lora.c
+++ b/twr/src/twr_at_lora.c
@@ -182,35 +182,35 @@ bool twr_at_lora_mode_set(twr_atci_param_t *param)
     return true;
 }
 
-bool twr_at_lora_join(void)
+bool twr_at_lora_join(twr_atci_param_t *param)
 {
     twr_cmwx1zzabz_join(_at.lora);
 
     return true;
 }
 
-bool twr_at_lora_frmcnt(void)
+bool twr_at_lora_frmcnt(twr_atci_param_t *param)
 {
     twr_cmwx1zzabz_frame_counter(_at.lora);
 
     return true;
 }
 
-bool twr_at_lora_reboot(void)
+bool twr_at_lora_reboot(twr_atci_param_t *param)
 {
     twr_system_reset();
 
     return true;
 }
 
-bool twr_at_lora_freset(void)
+bool twr_at_lora_freset(twr_atci_param_t *param)
 {
     twr_cmwx1zzabz_factory_reset(_at.lora);
 
     return true;
 }
 
-bool twr_at_lora_link_check(void)
+bool twr_at_lora_link_check(twr_atci_param_t *param)
 {
     twr_cmwx1zzabz_link_check(_at.lora);
 
@@ -225,7 +225,7 @@ bool twr_at_lora_custom_at_set(twr_atci_param_t *param)
     return true;
 }
 
-bool twr_at_lora_rfq(void)
+bool twr_at_lora_rfq(twr_atci_param_t *param)
 {
     twr_cmwx1zzabz_rfq(_at.lora);
 
@@ -347,7 +347,7 @@ bool twr_at_lora_repc_set(twr_atci_param_t *param)
     return true;
 }
 
-bool twr_at_lora_ver_read(void)
+bool twr_at_lora_ver_read(twr_atci_param_t *param)
 {
     const char *version = twr_cmwx1zzabz_get_fw_version(_at.lora);
 

--- a/twr/src/twr_at_lora.c
+++ b/twr/src/twr_at_lora.c
@@ -219,7 +219,12 @@ bool twr_at_lora_link_check(twr_atci_param_t *param)
 
 bool twr_at_lora_custom_at(twr_atci_param_t *param)
 {
-    return twr_cmwx1zzabz_custom_at(_at.lora, param->txt);
+    bool rv = twr_cmwx1zzabz_custom_at(_at.lora, param->txt);
+    if (rv)
+    {
+        twr_atci_skip_response();
+    }
+    return rv;
 }
 
 bool twr_at_lora_rfq(twr_atci_param_t *param)

--- a/twr/src/twr_at_lora.c
+++ b/twr/src/twr_at_lora.c
@@ -217,9 +217,8 @@ bool twr_at_lora_link_check(twr_atci_param_t *param)
     return true;
 }
 
-bool twr_at_lora_custom_at_set(twr_atci_param_t *param)
+bool twr_at_lora_custom_at(twr_atci_param_t *param)
 {
-    // Skip 6 characters (AT$AT=)
     twr_cmwx1zzabz_custom_at(_at.lora, param->txt);
 
     return true;

--- a/twr/src/twr_at_lora.c
+++ b/twr/src/twr_at_lora.c
@@ -349,6 +349,28 @@ bool twr_at_lora_repc_set(twr_atci_param_t *param)
     return true;
 }
 
+bool twr_at_lora_lora2atci_read(void)
+{
+    twr_atci_printfln("$LORA>ATCI: %d", _at.lora->_atci);
+
+    return true;
+}
+
+bool twr_at_lora_lora2atci_set(twr_atci_param_t *param)
+{
+    uint8_t onoff = atoi(param->txt);
+
+    if (onoff > 1)
+    {
+        return false;
+    }
+
+    _at.lora->_atci = onoff;
+
+    return true;
+}
+
+
 bool twr_at_lora_ver_read(twr_atci_param_t *param)
 {
     const char *version = twr_cmwx1zzabz_get_fw_version(_at.lora);

--- a/twr/src/twr_at_lora.c
+++ b/twr/src/twr_at_lora.c
@@ -219,9 +219,7 @@ bool twr_at_lora_link_check(twr_atci_param_t *param)
 
 bool twr_at_lora_custom_at(twr_atci_param_t *param)
 {
-    twr_cmwx1zzabz_custom_at(_at.lora, param->txt);
-
-    return true;
+    return twr_cmwx1zzabz_custom_at(_at.lora, param->txt);
 }
 
 bool twr_at_lora_rfq(twr_atci_param_t *param)

--- a/twr/src/twr_atci.c
+++ b/twr/src/twr_atci.c
@@ -247,7 +247,7 @@ static bool _twr_atci_process_line(void)
         }
         else
         {
-            return false;
+            continue;
         }
 
         break;

--- a/twr/src/twr_atci.c
+++ b/twr/src/twr_atci.c
@@ -141,7 +141,7 @@ void twr_atci_write_error(void)
     twr_uart_write(TWR_ATCI_UART, "ERROR\r\n", 7);
 }
 
-bool twr_atci_clac_action(void)
+bool twr_atci_clac_action(twr_atci_param_t *param)
 {
     for (size_t i = 0; i < _twr_atci.commands_length; i++)
     {
@@ -150,7 +150,7 @@ bool twr_atci_clac_action(void)
     return true;
 }
 
-bool twr_atci_help_action(void)
+bool twr_atci_help_action(twr_atci_param_t *param)
 {
     for (size_t i = 0; i < _twr_atci.commands_length; i++)
     {
@@ -201,7 +201,7 @@ static bool _twr_atci_process_line(void)
         {
             if (command->action != NULL)
             {
-                return command->action();
+                return command->action(NULL);
             }
         }
         else if (line[command_len] == '=')
@@ -230,6 +230,19 @@ static bool _twr_atci_process_line(void)
             if (command->read != NULL)
             {
                 return command->read();
+            }
+        }
+        else if (line[command_len] == ' ' && command_len + 1 < length)
+        {
+            if (command->action != NULL)
+            {
+                twr_atci_param_t param = {
+                    .txt = line + command_len + 1,
+                    .length = length - command_len - 1,
+                    .offset = 0
+                };
+
+                return command->action(&param);
             }
         }
         else

--- a/twr/src/twr_cmwx1zzabz.c
+++ b/twr/src/twr_cmwx1zzabz.c
@@ -252,6 +252,11 @@ static void _twr_cmwx1zzabz_task(void *param)
 
                 while (_twr_cmwx1zzabz_read_response(self))
                 {
+                    if (self->_atci)
+                    {
+                        twr_atci_printf("$LORA: %s\r\n", self->_response);
+                    }
+
                     if (memcmp(self->_response, "+RECV=", 5) == 0)
                     {
                         self->_message_port = atoi(&self->_response[6]);
@@ -1170,8 +1175,11 @@ static void _twr_cmwx1zzabz_task(void *param)
                 }
 
                 // Pass the response received from the LoRa module to the
-                // application.
-                twr_atci_printf("$LORA: %s\r\n", self->_response);
+                // application over the ATCI if enabled.
+                if (self->_atci)
+                {
+                    twr_atci_printf("$LORA: %s\r\n", self->_response);
+                }
 
                 if (memcmp(self->_response, "+OK", 3) == 0)
                 {

--- a/twr/src/twr_cmwx1zzabz.c
+++ b/twr/src/twr_cmwx1zzabz.c
@@ -1155,7 +1155,6 @@ static void _twr_cmwx1zzabz_task(void *param)
                 // and others in future versions fails gracefully and jump to idle instead of ERROR state
                 if (memcmp(self->_response, "+ERR=-1", 7) == 0)
                 {
-                    self->_state = TWR_CMWX1ZZABZ_STATE_IDLE;
                     self->_cmd_frmcnt_uplink = 0;
                     self->_cmd_frmcnt_downlink = 0;
                     continue;

--- a/twr/src/twr_cmwx1zzabz.c
+++ b/twr/src/twr_cmwx1zzabz.c
@@ -1454,9 +1454,13 @@ bool twr_cmwx1zzabz_custom_at(twr_cmwx1zzabz_t *self, char *at_command)
         return false;
     }
 
-    self->_custom_command = true;
-    snprintf(self->_custom_command_buf, sizeof(self->_custom_command_buf), "%s\r", at_command);
+    int rv = snprintf(self->_custom_command_buf, sizeof(self->_custom_command_buf), "%s\r", at_command);
+    if (rv < 0 || rv >= sizeof(self->_custom_command_buf))
+    {
+        return false;
+    }
 
+    self->_custom_command = true;
     twr_scheduler_plan_now(self->_task_id);
 
     return true;


### PR DESCRIPTION
The aim of this patch series is to enable external LoRa modem management tools, such as my [Python tool](https://pypi.org/project/lora-modem-abz/), to interact with the LoRa modem through the Tower Core module ATCI. To this end, this patch series takes the original `AT$AT` command implementation and extends it to forward all responses and event notifications from the LoRa modem over the Core module ATCI. This gives the management tool full access to the LoRa modem over the Core module ATCI.

In order to enable `AT$AT` to be used as an action with arguments, this PR also extends the ATCI in twr-sdk to support action parameters in the same way they are supported in setters.

The PR creates an alias for `AT$AT` called `AT$LORA` and introduces a new AT command `AT$LORA>ATCI` that can be used to enable or disable the forwarding of responses and event notifications from the LoRa modem over the Core module ATCI. The two AT commands are meant to be used together as follows:
```txt
AT$LORA>ATCI=1
AT$LORA AT$JOIN
OK
...
$LORA: +OK
$LORA: +EVENT=1,1
...
AT$LORA>ATCI=0
```
The above sequence allows the management tool to trigger a LoRaWAN OTAA Join in the modem and wait for the event notification that signals whether the Join has succeeded.

When the forwarding of responses and asynchronous notifications are enabled, the data is prefixed with `$LORA: ` before it is written to the Core module ATCI to make it easy for the application to distinguish the data originating from the LoRa modem from other data.

Here is an example how this API is used by the LoRa modem Python management tool to obtain information about the modem through the Tower Core module:
```txt
(venv) janakj@holly python % ./lora.py -t -p /dev/tty.usbserial-14130
Device information for modem /dev/tty.usbserial-14130:
+---------------------+-------------------------------------------------------------------+
| Port configuration  | 9600 8N1                                                          |
| Device model        | ABZ                                                               |
| Firmware version    | 1.1.2-27-gbf5475f0 (modified) [LoRaMac-node 4.6.0-27-g772d29f4]   |
| Data encoding       | binary                                                            |
| LoRaWAN version     | 1.1.1 / 1.0.4 (1.0.4 for ABP)                                     |
| Regional parameters | RP002-1.0.3                                                       |
| Supported regions   | AS923 AU915 CN470 CN779 EU433 EU868 IN865 KR920 RU864 US915       |
| Device EUI          | 373836375E378F09                                                  |
+---------------------+-------------------------------------------------------------------+
Network activation information for modem /dev/tty.usbserial-14130:
+------------------+------------------+
| Network type     | public           |
| Activation       | OTAA             |
| Network ID       | 00000000         |
| Join EUI         | 0101010101010101 |
| Protocol version | LoRaWAN 1.0.4    |
| Device address   | 0010C300         |
+------------------+------------------+
Current state of modem /dev/tty.usbserial-14130:
+---------------------------+-------------------------------------------------------------+
| Current region            | EU868                                                       |
| LoRaWAN class             | A                                                           |
| Channel mask              | FF00                                                        |
| Data rate                 | SF12_125                                                    |
| Maximum message size      | 51 B                                                        |
| RF power index            | 0                                                           |
| ADR enabled               | True                                                        |
| Duty cycling enabled      | False                                                       |
| Join duty cycling enabled | False                                                       |
| Maximum EIRP              | 16 dBm                                                      |
| Uplink frame counter      | 0                                                           |
| Downlink frame counter    | 0                                                           |
| Last downlink RSSI        | 0 dBm                                                       |
| Last downlink SNR         | 0 dB                                                        |
| RX1 window                | Delay: 1000 ms                                              |
| RX2 window                | Delay: 2000 ms, Frequency: 869.525 MHz, Data rate: SF12_125 |
| Join response windows     | RX1: 5000 ms, RX2: 6000 ms                                  |
+---------------------------+-------------------------------------------------------------+
```
The command line tool `lora.py` (part of the Python package) gained new command line options `-t / --twr-sdk` that enable the integration. Almost all commands that the tool supports can now be performed directly through the Tower Core module ATCI.