### PR TITLE
Add application error type for invalid parameter

### DIFF
--- a/twr/inc/twr_error.h
+++ b/twr/inc/twr_error.h
@@ -9,6 +9,7 @@ typedef enum
     TWR_ERROR_LOG_NOT_INITIALIZED = 1,
     TWR_ERROR_ERROR_UNLOCK = 2,
     TWR_ERROR_CALLBACK = 3,
+    TWR_ERROR_INVALID_PARAMETER = 4,
 
 } twr_error_t;
 

--- a/twr/src/main.c
+++ b/twr/src/main.c
@@ -89,6 +89,11 @@ __attribute__((weak)) void application_error(twr_error_t code)
                     twr_log_error("TWR_ERROR_CALLBACK");
                     break;
                 }
+                case TWR_ERROR_INVALID_PARAMETER:
+                {
+                    twr_log_error("TWR_ERROR_INVALID_PARAMETER");
+                    break;
+                }
                 default:
                 {
                     break;

--- a/twr/src/twr_scheduler.c
+++ b/twr/src/twr_scheduler.c
@@ -76,6 +76,10 @@ twr_scheduler_task_id_t twr_scheduler_register(void (*task)(void *), void *param
 
 void twr_scheduler_unregister(twr_scheduler_task_id_t task_id)
 {
+    if (task_id >= TWR_SCHEDULER_MAX_TASKS)
+    {
+        application_error(TWR_ERROR_INVALID_PARAMETER);
+    }
     _twr_scheduler.pool[task_id].task = NULL;
 
     if (_twr_scheduler.max_task_id == task_id)
@@ -105,21 +109,37 @@ twr_tick_t twr_scheduler_get_spin_tick(void)
 
 void twr_scheduler_plan_now(twr_scheduler_task_id_t task_id)
 {
+    if (task_id >= TWR_SCHEDULER_MAX_TASKS)
+    {
+        application_error(TWR_ERROR_INVALID_PARAMETER);
+    }
     _twr_scheduler.pool[task_id].tick_execution = 0;
 }
 
 void twr_scheduler_plan_absolute(twr_scheduler_task_id_t task_id, twr_tick_t tick)
 {
+    if (task_id >= TWR_SCHEDULER_MAX_TASKS || _twr_scheduler.pool[task_id].task == NULL)
+    {
+        application_error(TWR_ERROR_INVALID_PARAMETER);
+    }
     _twr_scheduler.pool[task_id].tick_execution = tick;
 }
 
 void twr_scheduler_plan_relative(twr_scheduler_task_id_t task_id, twr_tick_t tick)
 {
+    if (task_id >= TWR_SCHEDULER_MAX_TASKS || _twr_scheduler.pool[task_id].task == NULL)
+    {
+        application_error(TWR_ERROR_INVALID_PARAMETER);
+    }
     _twr_scheduler.pool[task_id].tick_execution = _twr_scheduler.tick_spin + tick;
 }
 
 void twr_scheduler_plan_from_now(twr_scheduler_task_id_t task_id, twr_tick_t tick)
 {
+    if (task_id >= TWR_SCHEDULER_MAX_TASKS || _twr_scheduler.pool[task_id].task == NULL)
+    {
+        application_error(TWR_ERROR_INVALID_PARAMETER);
+    }
     _twr_scheduler.pool[task_id].tick_execution = twr_tick_get() + tick;
 }
 


### PR DESCRIPTION
For example, this can be used in the default case of switch-case statements that are intended to cover all values of an enum:

https://github.com/antoneliasson/twr-lcd-thermometer/blob/b82c2e0ac3b31e709fbe49ce4a094ff4c8c1214b/src/application.c#L133
https://github.com/antoneliasson/twr-mailbox-monitor/blob/main/src/application.c#L90
